### PR TITLE
Sanitzation of internal .get_*() functions and encoding fix in login().

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ vignettes/*.pdf
 
 # Jupyter Notebook
 .ipynb_checkpoints
+.Rproj.user

--- a/R/get_aqua_site.R
+++ b/R/get_aqua_site.R
@@ -1,7 +1,7 @@
 .get_aqua_site <- function() {
   
   aqua_site <- "AquaServices"
-  
+
   aqua_site
   
 }

--- a/R/get_cache_site.R
+++ b/R/get_cache_site.R
@@ -1,7 +1,7 @@
 .get_cache_site <- function() {
   
   cache_site <- "AquaCache"
-  
+
   cache_site
   
 }

--- a/R/get_host.R
+++ b/R/get_host.R
@@ -1,9 +1,7 @@
 .get_host <- function() {
   
-  if (nzchar(Sys.getenv("AQUAMONITOR"))) {
-    host <- "http://www.aquamonitor.no/"
-  } else {
-    host <- "https://test-aquamonitor.niva.no/"
+  if (!exists("host")) {
+    host <- "https://www.aquamonitor.niva.no/"
   }
   
   host

--- a/R/login.R
+++ b/R/login.R
@@ -12,11 +12,11 @@ login <- function(username = NULL, password = NULL) {
 
   if (is.null(username)) {
     username <- getPass::getPass("Username: ")
-    username <- enc2utf8(username)
+    Encoding(username) <- "UTF-8"
   }
   if (is.null(password)) {
     password <- getPass::getPass("Password: ")
-    password <- enc2utf8(password)
+    Encoding(password) <- "UTF-8"
   }
 
   aqua_site <- .get_aqua_site()

--- a/R/query.R
+++ b/R/query.R
@@ -8,30 +8,32 @@
                 where = "ANY",
                 result = "ANY"),
 
-  methods = list(initialize = function(where = NULL, token = NULL) {
-    where <<- where
-    token <<- token
-    key <<- NULL
-    table <<- NULL
-    result <<- NULL
-  },
+  methods = list(
 
-  map = function(table = NULL) {
-    if (is.null(token)) {
-      token <<- .login()
-    }
+    initialize = function(where = NULL, token = NULL) {
+      where <<- where
+      token <<- token
+      key <<- NULL
+      table <<- NULL
+      result <<- NULL
+    },
 
-    table <<- table
+    map = function(table = NULL) {
+      if (is.null(token)) {
+        token <<- .login()
+      }
 
-    if (is.null(key)) {
-      key <<- create_query()
-    }
+      table <<- table
 
-    if (!is.null(key)) {
-      result <<- wait_query()
-      if (is.null(result$ErrorMessage)) {
-        if (is.null(table)) {
-          return(result$CurrentStationIds)
+      if (is.null(key)) {
+        key <<- create_query()
+      }
+
+      if (!is.null(key)) {
+        result <<- wait_query()
+        if (is.null(result$ErrorMessage)) {
+          if (is.null(table)) {
+            return(result$CurrentStationIds)
           } else {
             return(result)
           }
@@ -39,70 +41,70 @@
           msg <- paste0("Query ended with an error: ", result$ErrorMessage)
           stop(msg, call. = FALSE)
         }
-    }
-  },
+      }
+    },
 
-  create_query = function() {
+    create_query = function() {
 
-    query <- list()
+      query <- list()
 
-    if (!is.null(table)) {
-      query[["From"]] <- list(list(Table = table))
-    }
-
-    if (!is.null(where)) {
-      query[["Where"]] <- where
-    }
-
-    cache_site <- .get_cache_site()
-
-    url <- paste0(cache_site, "/query/")
-
-    response <- .post_json(token, url, query)
-
-    if (is.null(response$Key)) {
-      msg <- paste0("Couldn't create query. Response: ", response)
-      stop(msg, call. = FALSE)
-    } else {
-      key <<- response$Key
-    }
-  },
-
-  wait_query = function() {
-
-    cache_site <- .get_cache_site()
-
-    url <- paste0(cache_site, "/query/", key)
-
-    response <- .get_json(token, url)
-
-    if (!is.null(response$Result)) {
-      while (response$Result$Ready == FALSE) {
-        Sys.sleep(1)
-        response <- .get_json(token, url)
+      if (!is.null(table)) {
+        query[["From"]] <- list(list(Table = table))
       }
 
-      if (is.null(table)) {
-        result <<- response$Result
+      if (!is.null(where)) {
+        query[["Where"]] <- where
+      }
+
+      cache_site <- .get_cache_site()
+
+      url <- paste0(cache_site, "/query/")
+
+      response <- .post_json(token, url, query)
+
+      if (is.null(response$Key)) {
+        msg <- paste0("Couldn't create query. Response: ", response)
+        stop(msg, call. = FALSE)
       } else {
-        url <- paste(url, table, sep = "/")
-        response <- .get_json(token, url)
-
-        if (!is.null(response$Ready)) {
-          while (response$Ready == FALSE) {
-            Sys.sleep(1)
-            response <- .get_json(token, url)
-          }
-
-          result <<- response
-        } else {
-          msg <- paste0("Query didn't respond properly for table request: ", table)
-          stop(msg, call. = FALSE)
-        }
+        key <<- response$Key
       }
-    } else {
-      stop("Query didn't respond properly.", call. = FALSE)
+    },
+
+    wait_query = function() {
+
+      cache_site <- .get_cache_site()
+
+      url <- paste0(cache_site, "/query/", key)
+
+      response <- .get_json(token, url)
+
+      if (!is.null(response$Result)) {
+        while (response$Result$Ready == FALSE) {
+          Sys.sleep(1)
+          response <- .get_json(token, url)
+        }
+
+        if (is.null(table)) {
+          result <<- response$Result
+        } else {
+          url <- paste(url, table, sep = "/")
+          response <- .get_json(token, url)
+
+          if (!is.null(response$Ready)) {
+            while (response$Ready == FALSE) {
+              Sys.sleep(1)
+              response <- .get_json(token, url)
+            }
+
+            result <<- response
+          } else {
+            msg <- paste0("Query didn't respond properly for table request: ", table)
+            stop(msg, call. = FALSE)
+          }
+        }
+      } else {
+        stop("Query didn't respond properly.", call. = FALSE)
+      }
     }
-  }
   )
 )

--- a/README.Rmd
+++ b/README.Rmd
@@ -7,8 +7,6 @@ output: github_document
 knitr::opts_chunk$set(echo = TRUE)
 ```
 
-# aquamonitR
-
 Query the Nivabase directly from your R code and get results back as R data.frames. {aquamonitR} uses the Aquamonitor API to access the Nivabase securely, regardless of whether you're logged in to the NIVA network/VPN. 
 
 This repository is currently just a rough translation of the essential parts of Roar's [Aquamonitor-Python](https://github.com/NIVANorge/Aquamonitor-Python) library. The functionality of both libraries is currently limited, and development here will lag development of Aquamonitor-Python.
@@ -17,7 +15,7 @@ This repository is currently just a rough translation of the essential parts of 
 
 ```{r,eval=FALSE}
 # install.packages("devtools")
-remotes::install_github("RaoulWolf/aquamonitR")
+remotes::install_github("NIVANorge/aquamonitR")
 ```
 
 ## Quick start
@@ -25,8 +23,8 @@ remotes::install_github("RaoulWolf/aquamonitR")
 ```{reval=FALSE}
 library(aquamonitR)
 
-# The host is automatically set to the test version.
-# This will be changed in the future
+# this is to overwrite the standard host
+host <- "https://test-aquamonitor.niva.no/"
 
 # Login
 token <- login()
@@ -43,7 +41,6 @@ paste0(nrow(stn_df), "stations in project.")
 head(stn_df)
 
 # Get water chemistry for project and time period
-proj_id <- 12433
 st_dt <- "01.01.2019"
 end_dt <- "31.12.2019"
 df <- get_project_chemistry(proj_id, st_dt, end_dt, token = token)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 aquamonitR
 ================
 
-# aquamonitR
-
 Query the Nivabase directly from your R code and get results back as R
 data.frames. {aquamonitR} uses the Aquamonitor API to access the
 Nivabase securely, regardless of whether you’re logged in to the NIVA
@@ -18,15 +16,15 @@ development here will lag development of Aquamonitor-Python.
 
 ``` r
 # install.packages("devtools")
-remotes::install_github("RaoulWolf/aquamonitR")
+remotes::install_github("NIVANorge/aquamonitR")
 ```
 
 ## Quick start
 
     library(aquamonitR)
     
-    # The host is automatically set to the test version.
-    # This will be changed in the future
+    # this is to overwrite the standard host
+    host <- "https://test-aquamonitor.niva.no/"
     
     # Login
     token <- login()
@@ -43,7 +41,6 @@ remotes::install_github("RaoulWolf/aquamonitR")
     head(stn_df)
     
     # Get water chemistry for project and time period
-    proj_id <- 12433
     st_dt <- "01.01.2019"
     end_dt <- "31.12.2019"
     df <- get_project_chemistry(proj_id, st_dt, end_dt, token = token)

--- a/aquamonitR.Rproj
+++ b/aquamonitR.Rproj
@@ -1,7 +1,7 @@
 Version: 1.0
 
-RestoreWorkspace: Default
-SaveWorkspace: Default
+RestoreWorkspace: No
+SaveWorkspace: No
 AlwaysSaveHistory: Default
 
 EnableCodeIndexing: Yes
@@ -11,3 +11,12 @@ Encoding: UTF-8
 
 RnwWeave: Sweave
 LaTeX: pdfLaTeX
+
+AutoAppendNewline: Yes
+StripTrailingWhitespace: Yes
+LineEndingConversion: Posix
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source
+PackageRoxygenize: rd,collate,namespace


### PR DESCRIPTION
As the title says, I tried to sanitize the following internal functions:

* `.get_aqua_site()`,
* `.get_cache_site()`, and
* `.get_host()`.

`.get_aqua_site()` and `.get_cache_site()` simply return the original hard coded values (`AquaServices` and `AquaCache`, respectively). The definition is a bit verbose, but makes it easier to implement changes in the future, in case the default values should be changeable by the user. 
`.get_host()` now first checks if a `host` object already exists in the global environment, i.e., the active R session. If it does indeed exist, this will be used as host URL. Otherwise the default host URL (`https://www.aquamonitor.niva.no/`) is used. This also means that the test host URL (`https://test-aquamonitor.niva.no/`) needs to be explicitly specified again; which seems to be a fair trade-off. 

Elsewhere, I realized I messed up the encoding of provided values in the `login()` function. I didn't notice it because I don't use special characters, but now it's fixed and should work also with special characters. 

I also tried to improve the readability of the `.query()` code. 

Feel free to use the parts you find important/necessary!