### PR TITLE
Fix queries following updates in Aquamonitor-Python

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: aquamonitR
 Title: Query the Nivabase Directly From Your R Code
-Version: 0.0.0.9001
+Version: 0.0.0.9002
 Date: 2021-02-04
-Authors@R: 
+Authors@R:
   c(person(given = "James Edward",
            family = "Sample",
            email = "jes@niva.no",
@@ -13,16 +13,17 @@ Authors@R:
            email = "raw@niva.no",
            role = "aut",
            comment = c(ORCID = "0000-0001-5971-8525")))
-Description: Query the Nivabase directly from your R code and get results back as R data.frames. 
-  {aquamonitR} uses the Aquamonitor API to access the Nivabase securely, 
-  regardless of whether you're logged in to the NIVA network/VPN. 
+Description: Query the Nivabase directly from your R code and get results back as R data.frames.
+  {aquamonitR} uses the Aquamonitor API to access the Nivabase securely,
+  regardless of whether you're logged in to the NIVA network/VPN.
 License: MIT + file LICENSE
 Depends: R (>= 3.5.0)
 Imports:
   curl,
   getPass,
   jsonlite,
-  methods
+  methods,
+  dplyr
 URL: https://github.com/NIVANorge/aquamonitR
 BugReports: https://github.com/NIVANorge/aquamonitR/issues
 Encoding: UTF-8

--- a/R/get_project_chemistry.R
+++ b/R/get_project_chemistry.R
@@ -39,7 +39,7 @@ get_project_chemistry <- function(proj_id, st_dt, end_dt, token = NULL, na.rm = 
 
   }
 
-  df <- do.call(rbind, df_list)
+  df <- do.call(dplyr::bind_rows, df_list)
 
   if (na.rm) {
 

--- a/R/get_project_chemistry.R
+++ b/R/get_project_chemistry.R
@@ -63,9 +63,13 @@ get_project_chemistry <- function(proj_id, st_dt, end_dt, token = NULL, na.rm = 
   #
   # }
 
-  df <- df[, c("Sample.Station.Project.Id", "Sample.Station.Project.Name", "Sample.Station.Id", "Sample.Station.Code", "Sample.Station.Name", "Sample.SampleDate", "Sample.Depth1", "Sample.Depth2", "Parameter.Name", "Flag", "Value", "Parameter.Unit")]
+  # Split the timestamp into the date & time part
+  df$SampleDate <- as.Date(df$Sample.SampleDate)
+  df$SampleTime <- format(df$Sample.SampleDate, format = "%H:%M:%S")
 
-  names(df) <- c("project_id", "project_name", "station_id", "station_code", "station_name", "sample_date", "depth1", "depth2", "parameter_name", "flag", "value", "unit")
+  df <- df[, c("Sample.Station.Project.Id", "Sample.Station.Project.Name", "Sample.Station.Id", "Sample.Station.Code", "Sample.Station.Name", "SampleDate", "SampleTime", "Sample.Depth1", "Sample.Depth2", "Parameter.Name", "Flag", "Value", "Parameter.Unit")]
+
+  names(df) <- c("project_id", "project_name", "station_id", "station_code", "station_name", "sample_date", "sample_time", "depth1", "depth2", "parameter_name", "flag", "value", "unit")
 
   df
 

--- a/R/get_projects.R
+++ b/R/get_projects.R
@@ -19,9 +19,9 @@ get_projects <- function(token = NULL) {
 
   df <- get_json(token, url)
 
-  df <- df[, c("Id", "Number", "Name", "Description")]
+  df <- df[, c("Id", "Name", "Description", "O_Numbers")]
 
-  names(df) <- c("project_id", "project_code", "project_name", "description")
+  names(df) <- c("project_id", "project_name", "description", "project_code")
 
   df
 

--- a/examples/query_chem.ipynb
+++ b/examples/query_chem.ipynb
@@ -3,7 +3,11 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "library(\"aquamonitR\")"
@@ -28,17 +32,12 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdin",
-     "output_type": "stream",
-     "text": [
-      "Username: ···\n",
-      "Password: ··············\n"
-     ]
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
     }
-   ],
+   },
+   "outputs": [],
    "source": [
     "# Login to AM\n",
     "token <- login()"
@@ -56,21 +55,25 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [
     {
      "data": {
       "text/html": [
-       "'1334 projects in the database.'"
+       "'1507 projects in the database.'"
       ],
       "text/latex": [
-       "'1334 projects in the database.'"
+       "'1507 projects in the database.'"
       ],
       "text/markdown": [
-       "'1334 projects in the database.'"
+       "'1507 projects in the database.'"
       ],
       "text/plain": [
-       "[1] \"1334 projects in the database.\""
+       "[1] \"1507 projects in the database.\""
       ]
      },
      "metadata": {},
@@ -82,55 +85,55 @@
        "<table class=\"dataframe\">\n",
        "<caption>A data.frame: 6 × 4</caption>\n",
        "<thead>\n",
-       "\t<tr><th></th><th scope=col>project_id</th><th scope=col>project_code</th><th scope=col>project_name</th><th scope=col>description</th></tr>\n",
-       "\t<tr><th></th><th scope=col>&lt;int&gt;</th><th scope=col>&lt;chr&gt;</th><th scope=col>&lt;chr&gt;</th><th scope=col>&lt;chr&gt;</th></tr>\n",
+       "\t<tr><th></th><th scope=col>project_id</th><th scope=col>project_name</th><th scope=col>description</th><th scope=col>project_code</th></tr>\n",
+       "\t<tr><th></th><th scope=col>&lt;int&gt;</th><th scope=col>&lt;chr&gt;</th><th scope=col>&lt;chr&gt;</th><th scope=col>&lt;list&gt;</th></tr>\n",
        "</thead>\n",
        "<tbody>\n",
-       "\t<tr><th scope=row>1</th><td> 1</td><td>NA</td><td>xxx            </td><td>NA     </td></tr>\n",
-       "\t<tr><th scope=row>2</th><td>55</td><td>NA</td><td>PARCOM_Aquateam</td><td>NA     </td></tr>\n",
-       "\t<tr><th scope=row>3</th><td>56</td><td>NA</td><td>PARCOM_NIVA    </td><td>NA     </td></tr>\n",
-       "\t<tr><th scope=row>4</th><td>58</td><td>NA</td><td>MAR_BOK        </td><td>Fagdata</td></tr>\n",
-       "\t<tr><th scope=row>5</th><td>59</td><td>NA</td><td>MAR_IMA        </td><td>Fagdata</td></tr>\n",
-       "\t<tr><th scope=row>6</th><td>60</td><td>NA</td><td>MAR_JOK        </td><td>Fagdata</td></tr>\n",
+       "\t<tr><th scope=row>1</th><td>2380</td><td>Trondheimsfjorden 1540_83     </td><td>1540_83  </td><td>NULL</td></tr>\n",
+       "\t<tr><th scope=row>2</th><td>2381</td><td>Trondheimsfjorden 1641_84     </td><td>1641_84  </td><td>NULL</td></tr>\n",
+       "\t<tr><th scope=row>3</th><td>2382</td><td>Tvedestrand supp. sedimentund.</td><td>4986-2005</td><td>188  , 24278</td></tr>\n",
+       "\t<tr><th scope=row>4</th><td>2383</td><td>Varangerfjorden 2213_89       </td><td>2213_89  </td><td>NULL</td></tr>\n",
+       "\t<tr><th scope=row>5</th><td>2384</td><td>Varangerfjorden 3281_95       </td><td>3281_95  </td><td>NULL</td></tr>\n",
+       "\t<tr><th scope=row>6</th><td>2385</td><td>Vefsnfjorden 1330_81          </td><td>1330_81  </td><td>NULL</td></tr>\n",
        "</tbody>\n",
        "</table>\n"
       ],
       "text/latex": [
        "A data.frame: 6 × 4\n",
        "\\begin{tabular}{r|llll}\n",
-       "  & project\\_id & project\\_code & project\\_name & description\\\\\n",
-       "  & <int> & <chr> & <chr> & <chr>\\\\\n",
+       "  & project\\_id & project\\_name & description & project\\_code\\\\\n",
+       "  & <int> & <chr> & <chr> & <list>\\\\\n",
        "\\hline\n",
-       "\t1 &  1 & NA & xxx             & NA     \\\\\n",
-       "\t2 & 55 & NA & PARCOM\\_Aquateam & NA     \\\\\n",
-       "\t3 & 56 & NA & PARCOM\\_NIVA     & NA     \\\\\n",
-       "\t4 & 58 & NA & MAR\\_BOK         & Fagdata\\\\\n",
-       "\t5 & 59 & NA & MAR\\_IMA         & Fagdata\\\\\n",
-       "\t6 & 60 & NA & MAR\\_JOK         & Fagdata\\\\\n",
+       "\t1 & 2380 & Trondheimsfjorden 1540\\_83      & 1540\\_83   & NULL\\\\\n",
+       "\t2 & 2381 & Trondheimsfjorden 1641\\_84      & 1641\\_84   & NULL\\\\\n",
+       "\t3 & 2382 & Tvedestrand supp. sedimentund. & 4986-2005 & 188  , 24278\\\\\n",
+       "\t4 & 2383 & Varangerfjorden 2213\\_89        & 2213\\_89   & NULL\\\\\n",
+       "\t5 & 2384 & Varangerfjorden 3281\\_95        & 3281\\_95   & NULL\\\\\n",
+       "\t6 & 2385 & Vefsnfjorden 1330\\_81           & 1330\\_81   & NULL\\\\\n",
        "\\end{tabular}\n"
       ],
       "text/markdown": [
        "\n",
        "A data.frame: 6 × 4\n",
        "\n",
-       "| <!--/--> | project_id &lt;int&gt; | project_code &lt;chr&gt; | project_name &lt;chr&gt; | description &lt;chr&gt; |\n",
+       "| <!--/--> | project_id &lt;int&gt; | project_name &lt;chr&gt; | description &lt;chr&gt; | project_code &lt;list&gt; |\n",
        "|---|---|---|---|---|\n",
-       "| 1 |  1 | NA | xxx             | NA      |\n",
-       "| 2 | 55 | NA | PARCOM_Aquateam | NA      |\n",
-       "| 3 | 56 | NA | PARCOM_NIVA     | NA      |\n",
-       "| 4 | 58 | NA | MAR_BOK         | Fagdata |\n",
-       "| 5 | 59 | NA | MAR_IMA         | Fagdata |\n",
-       "| 6 | 60 | NA | MAR_JOK         | Fagdata |\n",
+       "| 1 | 2380 | Trondheimsfjorden 1540_83      | 1540_83   | NULL |\n",
+       "| 2 | 2381 | Trondheimsfjorden 1641_84      | 1641_84   | NULL |\n",
+       "| 3 | 2382 | Tvedestrand supp. sedimentund. | 4986-2005 | 188  , 24278 |\n",
+       "| 4 | 2383 | Varangerfjorden 2213_89        | 2213_89   | NULL |\n",
+       "| 5 | 2384 | Varangerfjorden 3281_95        | 3281_95   | NULL |\n",
+       "| 6 | 2385 | Vefsnfjorden 1330_81           | 1330_81   | NULL |\n",
        "\n"
       ],
       "text/plain": [
-       "  project_id project_code project_name    description\n",
-       "1  1         NA           xxx             NA         \n",
-       "2 55         NA           PARCOM_Aquateam NA         \n",
-       "3 56         NA           PARCOM_NIVA     NA         \n",
-       "4 58         NA           MAR_BOK         Fagdata    \n",
-       "5 59         NA           MAR_IMA         Fagdata    \n",
-       "6 60         NA           MAR_JOK         Fagdata    "
+       "  project_id project_name                   description project_code\n",
+       "1 2380       Trondheimsfjorden 1540_83      1540_83     NULL        \n",
+       "2 2381       Trondheimsfjorden 1641_84      1641_84     NULL        \n",
+       "3 2382       Tvedestrand supp. sedimentund. 4986-2005   188  , 24278\n",
+       "4 2383       Varangerfjorden 2213_89        2213_89     NULL        \n",
+       "5 2384       Varangerfjorden 3281_95        3281_95     NULL        \n",
+       "6 2385       Vefsnfjorden 1330_81           1330_81     NULL        "
       ]
      },
      "metadata": {},
@@ -146,7 +149,11 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -154,37 +161,37 @@
        "<table class=\"dataframe\">\n",
        "<caption>A data.frame: 1 × 4</caption>\n",
        "<thead>\n",
-       "\t<tr><th></th><th scope=col>project_id</th><th scope=col>project_code</th><th scope=col>project_name</th><th scope=col>description</th></tr>\n",
-       "\t<tr><th></th><th scope=col>&lt;int&gt;</th><th scope=col>&lt;chr&gt;</th><th scope=col>&lt;chr&gt;</th><th scope=col>&lt;chr&gt;</th></tr>\n",
+       "\t<tr><th></th><th scope=col>project_id</th><th scope=col>project_name</th><th scope=col>description</th><th scope=col>project_code</th></tr>\n",
+       "\t<tr><th></th><th scope=col>&lt;int&gt;</th><th scope=col>&lt;chr&gt;</th><th scope=col>&lt;chr&gt;</th><th scope=col>&lt;list&gt;</th></tr>\n",
        "</thead>\n",
        "<tbody>\n",
-       "\t<tr><th scope=row>1202</th><td>12433</td><td>190091</td><td>Nasjonal Innsjøundersøkelse 2019</td><td>1000-sjøer undersøkelse gjennomført i 2019</td></tr>\n",
+       "\t<tr><th scope=row>1327</th><td>12433</td><td>Nasjonal Innsjøundersøkelse 2019</td><td>1000-sjøer undersøkelse gjennomført i 2019</td><td>8619  , 190091</td></tr>\n",
        "</tbody>\n",
        "</table>\n"
       ],
       "text/latex": [
        "A data.frame: 1 × 4\n",
        "\\begin{tabular}{r|llll}\n",
-       "  & project\\_id & project\\_code & project\\_name & description\\\\\n",
-       "  & <int> & <chr> & <chr> & <chr>\\\\\n",
+       "  & project\\_id & project\\_name & description & project\\_code\\\\\n",
+       "  & <int> & <chr> & <chr> & <list>\\\\\n",
        "\\hline\n",
-       "\t1202 & 12433 & 190091 & Nasjonal Innsjøundersøkelse 2019 & 1000-sjøer undersøkelse gjennomført i 2019\\\\\n",
+       "\t1327 & 12433 & Nasjonal Innsjøundersøkelse 2019 & 1000-sjøer undersøkelse gjennomført i 2019 & 8619  , 190091\\\\\n",
        "\\end{tabular}\n"
       ],
       "text/markdown": [
        "\n",
        "A data.frame: 1 × 4\n",
        "\n",
-       "| <!--/--> | project_id &lt;int&gt; | project_code &lt;chr&gt; | project_name &lt;chr&gt; | description &lt;chr&gt; |\n",
+       "| <!--/--> | project_id &lt;int&gt; | project_name &lt;chr&gt; | description &lt;chr&gt; | project_code &lt;list&gt; |\n",
        "|---|---|---|---|---|\n",
-       "| 1202 | 12433 | 190091 | Nasjonal Innsjøundersøkelse 2019 | 1000-sjøer undersøkelse gjennomført i 2019 |\n",
+       "| 1327 | 12433 | Nasjonal Innsjøundersøkelse 2019 | 1000-sjøer undersøkelse gjennomført i 2019 | 8619  , 190091 |\n",
        "\n"
       ],
       "text/plain": [
-       "     project_id project_code project_name                    \n",
-       "1202 12433      190091       Nasjonal Innsjøundersøkelse 2019\n",
-       "     description                               \n",
-       "1202 1000-sjøer undersøkelse gjennomført i 2019"
+       "     project_id project_name                    \n",
+       "1327 12433      Nasjonal Innsjøundersøkelse 2019\n",
+       "     description                                project_code  \n",
+       "1327 1000-sjøer undersøkelse gjennomført i 2019 8619  , 190091"
       ]
      },
      "metadata": {},
@@ -210,7 +217,11 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -240,12 +251,12 @@
        "\t<tr><th></th><th scope=col>&lt;int&gt;</th><th scope=col>&lt;int&gt;</th><th scope=col>&lt;chr&gt;</th><th scope=col>&lt;chr&gt;</th><th scope=col>&lt;chr&gt;</th></tr>\n",
        "</thead>\n",
        "<tbody>\n",
-       "\t<tr><th scope=row>1</th><td>12433</td><td>26104</td><td>1037-1-1 </td><td>Lisle Frøysvatnet</td><td>Innsjø</td></tr>\n",
-       "\t<tr><th scope=row>2</th><td>12433</td><td>26105</td><td>1046-1-23</td><td>Bergetjørni      </td><td>Innsjø</td></tr>\n",
-       "\t<tr><th scope=row>3</th><td>12433</td><td>26106</td><td>1114-1-20</td><td>Skjelbreidtjørni </td><td>Innsjø</td></tr>\n",
-       "\t<tr><th scope=row>4</th><td>12433</td><td>26107</td><td>1114-1-34</td><td>Lomstjørni       </td><td>Innsjø</td></tr>\n",
-       "\t<tr><th scope=row>5</th><td>12433</td><td>26108</td><td>1122-1-9 </td><td>Kråtjørni        </td><td>Innsjø</td></tr>\n",
-       "\t<tr><th scope=row>6</th><td>12433</td><td>26109</td><td>1129-1-13</td><td>Tvaravatnet      </td><td>Innsjø</td></tr>\n",
+       "\t<tr><th scope=row>1</th><td>12433</td><td>71716</td><td>128-2-200</td><td>Langevatnet   </td><td>Innsjø</td></tr>\n",
+       "\t<tr><th scope=row>2</th><td>12433</td><td>71717</td><td>402-2-201</td><td>Damtjenn      </td><td>Innsjø</td></tr>\n",
+       "\t<tr><th scope=row>3</th><td>12433</td><td>26825</td><td>1742-1-7 </td><td>HOH 824       </td><td>Innsjø</td></tr>\n",
+       "\t<tr><th scope=row>4</th><td>12433</td><td>26824</td><td>1742-1-1 </td><td>Liatjørnin    </td><td>Innsjø</td></tr>\n",
+       "\t<tr><th scope=row>5</th><td>12433</td><td>26793</td><td>1718-1-10</td><td>Storskartjørna</td><td>Innsjø</td></tr>\n",
+       "\t<tr><th scope=row>6</th><td>12433</td><td>26790</td><td>1717-2-6 </td><td>Liavatnet     </td><td>Innsjø</td></tr>\n",
        "</tbody>\n",
        "</table>\n"
       ],
@@ -255,12 +266,12 @@
        "  & project\\_id & station\\_id & station\\_code & station\\_name & type\\\\\n",
        "  & <int> & <int> & <chr> & <chr> & <chr>\\\\\n",
        "\\hline\n",
-       "\t1 & 12433 & 26104 & 1037-1-1  & Lisle Frøysvatnet & Innsjø\\\\\n",
-       "\t2 & 12433 & 26105 & 1046-1-23 & Bergetjørni       & Innsjø\\\\\n",
-       "\t3 & 12433 & 26106 & 1114-1-20 & Skjelbreidtjørni  & Innsjø\\\\\n",
-       "\t4 & 12433 & 26107 & 1114-1-34 & Lomstjørni        & Innsjø\\\\\n",
-       "\t5 & 12433 & 26108 & 1122-1-9  & Kråtjørni         & Innsjø\\\\\n",
-       "\t6 & 12433 & 26109 & 1129-1-13 & Tvaravatnet       & Innsjø\\\\\n",
+       "\t1 & 12433 & 71716 & 128-2-200 & Langevatnet    & Innsjø\\\\\n",
+       "\t2 & 12433 & 71717 & 402-2-201 & Damtjenn       & Innsjø\\\\\n",
+       "\t3 & 12433 & 26825 & 1742-1-7  & HOH 824        & Innsjø\\\\\n",
+       "\t4 & 12433 & 26824 & 1742-1-1  & Liatjørnin     & Innsjø\\\\\n",
+       "\t5 & 12433 & 26793 & 1718-1-10 & Storskartjørna & Innsjø\\\\\n",
+       "\t6 & 12433 & 26790 & 1717-2-6  & Liavatnet      & Innsjø\\\\\n",
        "\\end{tabular}\n"
       ],
       "text/markdown": [
@@ -269,22 +280,22 @@
        "\n",
        "| <!--/--> | project_id &lt;int&gt; | station_id &lt;int&gt; | station_code &lt;chr&gt; | station_name &lt;chr&gt; | type &lt;chr&gt; |\n",
        "|---|---|---|---|---|---|\n",
-       "| 1 | 12433 | 26104 | 1037-1-1  | Lisle Frøysvatnet | Innsjø |\n",
-       "| 2 | 12433 | 26105 | 1046-1-23 | Bergetjørni       | Innsjø |\n",
-       "| 3 | 12433 | 26106 | 1114-1-20 | Skjelbreidtjørni  | Innsjø |\n",
-       "| 4 | 12433 | 26107 | 1114-1-34 | Lomstjørni        | Innsjø |\n",
-       "| 5 | 12433 | 26108 | 1122-1-9  | Kråtjørni         | Innsjø |\n",
-       "| 6 | 12433 | 26109 | 1129-1-13 | Tvaravatnet       | Innsjø |\n",
+       "| 1 | 12433 | 71716 | 128-2-200 | Langevatnet    | Innsjø |\n",
+       "| 2 | 12433 | 71717 | 402-2-201 | Damtjenn       | Innsjø |\n",
+       "| 3 | 12433 | 26825 | 1742-1-7  | HOH 824        | Innsjø |\n",
+       "| 4 | 12433 | 26824 | 1742-1-1  | Liatjørnin     | Innsjø |\n",
+       "| 5 | 12433 | 26793 | 1718-1-10 | Storskartjørna | Innsjø |\n",
+       "| 6 | 12433 | 26790 | 1717-2-6  | Liavatnet      | Innsjø |\n",
        "\n"
       ],
       "text/plain": [
-       "  project_id station_id station_code station_name      type  \n",
-       "1 12433      26104      1037-1-1     Lisle Frøysvatnet Innsjø\n",
-       "2 12433      26105      1046-1-23    Bergetjørni       Innsjø\n",
-       "3 12433      26106      1114-1-20    Skjelbreidtjørni  Innsjø\n",
-       "4 12433      26107      1114-1-34    Lomstjørni        Innsjø\n",
-       "5 12433      26108      1122-1-9     Kråtjørni         Innsjø\n",
-       "6 12433      26109      1129-1-13    Tvaravatnet       Innsjø"
+       "  project_id station_id station_code station_name   type  \n",
+       "1 12433      71716      128-2-200    Langevatnet    Innsjø\n",
+       "2 12433      71717      402-2-201    Damtjenn       Innsjø\n",
+       "3 12433      26825      1742-1-7     HOH 824        Innsjø\n",
+       "4 12433      26824      1742-1-1     Liatjørnin     Innsjø\n",
+       "5 12433      26793      1718-1-10    Storskartjørna Innsjø\n",
+       "6 12433      26790      1717-2-6     Liavatnet      Innsjø"
       ]
      },
      "metadata": {},
@@ -312,53 +323,57 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [
     {
      "data": {
       "text/html": [
        "<table class=\"dataframe\">\n",
-       "<caption>A data.frame: 6 × 12</caption>\n",
+       "<caption>A data.frame: 6 × 13</caption>\n",
        "<thead>\n",
-       "\t<tr><th></th><th scope=col>project_id</th><th scope=col>project_name</th><th scope=col>station_id</th><th scope=col>station_code</th><th scope=col>station_name</th><th scope=col>sample_date</th><th scope=col>depth1</th><th scope=col>depth2</th><th scope=col>parameter_name</th><th scope=col>flag</th><th scope=col>value</th><th scope=col>unit</th></tr>\n",
-       "\t<tr><th></th><th scope=col>&lt;int&gt;</th><th scope=col>&lt;chr&gt;</th><th scope=col>&lt;int&gt;</th><th scope=col>&lt;chr&gt;</th><th scope=col>&lt;chr&gt;</th><th scope=col>&lt;dttm&gt;</th><th scope=col>&lt;dbl&gt;</th><th scope=col>&lt;dbl&gt;</th><th scope=col>&lt;chr&gt;</th><th scope=col>&lt;chr&gt;</th><th scope=col>&lt;dbl&gt;</th><th scope=col>&lt;chr&gt;</th></tr>\n",
+       "\t<tr><th></th><th scope=col>project_id</th><th scope=col>project_name</th><th scope=col>station_id</th><th scope=col>station_code</th><th scope=col>station_name</th><th scope=col>sample_date</th><th scope=col>sample_time</th><th scope=col>depth1</th><th scope=col>depth2</th><th scope=col>parameter_name</th><th scope=col>flag</th><th scope=col>value</th><th scope=col>unit</th></tr>\n",
+       "\t<tr><th></th><th scope=col>&lt;int&gt;</th><th scope=col>&lt;chr&gt;</th><th scope=col>&lt;int&gt;</th><th scope=col>&lt;chr&gt;</th><th scope=col>&lt;chr&gt;</th><th scope=col>&lt;date&gt;</th><th scope=col>&lt;chr&gt;</th><th scope=col>&lt;dbl&gt;</th><th scope=col>&lt;dbl&gt;</th><th scope=col>&lt;chr&gt;</th><th scope=col>&lt;chr&gt;</th><th scope=col>&lt;dbl&gt;</th><th scope=col>&lt;chr&gt;</th></tr>\n",
        "</thead>\n",
        "<tbody>\n",
-       "\t<tr><th scope=row>1</th><td>12433</td><td>Nasjonal Innsjøundersøkelse 2019</td><td>71716</td><td>128-2-200</td><td>Langevatnet</td><td>2019-10-25</td><td>0</td><td>0</td><td>Cl       </td><td>NA</td><td>  4.140</td><td>mg/L</td></tr>\n",
-       "\t<tr><th scope=row>2</th><td>12433</td><td>Nasjonal Innsjøundersøkelse 2019</td><td>71716</td><td>128-2-200</td><td>Langevatnet</td><td>2019-10-25</td><td>0</td><td>0</td><td>Cd       </td><td>NA</td><td>  0.039</td><td>µg/l</td></tr>\n",
-       "\t<tr><th scope=row>3</th><td>12433</td><td>Nasjonal Innsjøundersøkelse 2019</td><td>71716</td><td>128-2-200</td><td>Langevatnet</td><td>2019-10-25</td><td>0</td><td>0</td><td>Fe       </td><td>NA</td><td>830.000</td><td>µg/l</td></tr>\n",
-       "\t<tr><th scope=row>4</th><td>12433</td><td>Nasjonal Innsjøundersøkelse 2019</td><td>71716</td><td>128-2-200</td><td>Langevatnet</td><td>2019-10-25</td><td>0</td><td>0</td><td>Mn       </td><td>NA</td><td> 19.000</td><td>µg/l</td></tr>\n",
-       "\t<tr><th scope=row>5</th><td>12433</td><td>Nasjonal Innsjøundersøkelse 2019</td><td>71716</td><td>128-2-200</td><td>Langevatnet</td><td>2019-10-25</td><td>0</td><td>0</td><td>Co       </td><td>NA</td><td>  0.760</td><td>µg/L</td></tr>\n",
-       "\t<tr><th scope=row>6</th><td>12433</td><td>Nasjonal Innsjøundersøkelse 2019</td><td>71716</td><td>128-2-200</td><td>Langevatnet</td><td>2019-10-25</td><td>0</td><td>0</td><td>NO3+NO2-N</td><td>NA</td><td> 46.000</td><td>µg/l</td></tr>\n",
+       "\t<tr><th scope=row>1</th><td>12433</td><td>Nasjonal Innsjøundersøkelse 2019</td><td>71716</td><td>128-2-200</td><td>Langevatnet</td><td>2019-10-24</td><td>00:00:00</td><td>0</td><td>0</td><td>Ca   </td><td>NA</td><td>  2.46</td><td>mg/L</td></tr>\n",
+       "\t<tr><th scope=row>2</th><td>12433</td><td>Nasjonal Innsjøundersøkelse 2019</td><td>71716</td><td>128-2-200</td><td>Langevatnet</td><td>2019-10-24</td><td>00:00:00</td><td>0</td><td>0</td><td>K    </td><td>NA</td><td>  0.27</td><td>mg/L</td></tr>\n",
+       "\t<tr><th scope=row>3</th><td>12433</td><td>Nasjonal Innsjøundersøkelse 2019</td><td>71716</td><td>128-2-200</td><td>Langevatnet</td><td>2019-10-24</td><td>00:00:00</td><td>0</td><td>0</td><td>Cl   </td><td>NA</td><td>  4.14</td><td>mg/L</td></tr>\n",
+       "\t<tr><th scope=row>4</th><td>12433</td><td>Nasjonal Innsjøundersøkelse 2019</td><td>71716</td><td>128-2-200</td><td>Langevatnet</td><td>2019-10-24</td><td>00:00:00</td><td>0</td><td>0</td><td>NH4-N</td><td>NA</td><td> 13.00</td><td>µg/l</td></tr>\n",
+       "\t<tr><th scope=row>5</th><td>12433</td><td>Nasjonal Innsjøundersøkelse 2019</td><td>71716</td><td>128-2-200</td><td>Langevatnet</td><td>2019-10-24</td><td>00:00:00</td><td>0</td><td>0</td><td>TOC  </td><td>NA</td><td> 19.70</td><td>mg/l</td></tr>\n",
+       "\t<tr><th scope=row>6</th><td>12433</td><td>Nasjonal Innsjøundersøkelse 2019</td><td>71716</td><td>128-2-200</td><td>Langevatnet</td><td>2019-10-24</td><td>00:00:00</td><td>0</td><td>0</td><td>Al   </td><td>NA</td><td>390.00</td><td>µg/l</td></tr>\n",
        "</tbody>\n",
        "</table>\n"
       ],
       "text/latex": [
-       "A data.frame: 6 × 12\n",
-       "\\begin{tabular}{r|llllllllllll}\n",
-       "  & project\\_id & project\\_name & station\\_id & station\\_code & station\\_name & sample\\_date & depth1 & depth2 & parameter\\_name & flag & value & unit\\\\\n",
-       "  & <int> & <chr> & <int> & <chr> & <chr> & <dttm> & <dbl> & <dbl> & <chr> & <chr> & <dbl> & <chr>\\\\\n",
+       "A data.frame: 6 × 13\n",
+       "\\begin{tabular}{r|lllllllllllll}\n",
+       "  & project\\_id & project\\_name & station\\_id & station\\_code & station\\_name & sample\\_date & sample\\_time & depth1 & depth2 & parameter\\_name & flag & value & unit\\\\\n",
+       "  & <int> & <chr> & <int> & <chr> & <chr> & <date> & <chr> & <dbl> & <dbl> & <chr> & <chr> & <dbl> & <chr>\\\\\n",
        "\\hline\n",
-       "\t1 & 12433 & Nasjonal Innsjøundersøkelse 2019 & 71716 & 128-2-200 & Langevatnet & 2019-10-25 & 0 & 0 & Cl        & NA &   4.140 & mg/L\\\\\n",
-       "\t2 & 12433 & Nasjonal Innsjøundersøkelse 2019 & 71716 & 128-2-200 & Langevatnet & 2019-10-25 & 0 & 0 & Cd        & NA &   0.039 & µg/l\\\\\n",
-       "\t3 & 12433 & Nasjonal Innsjøundersøkelse 2019 & 71716 & 128-2-200 & Langevatnet & 2019-10-25 & 0 & 0 & Fe        & NA & 830.000 & µg/l\\\\\n",
-       "\t4 & 12433 & Nasjonal Innsjøundersøkelse 2019 & 71716 & 128-2-200 & Langevatnet & 2019-10-25 & 0 & 0 & Mn        & NA &  19.000 & µg/l\\\\\n",
-       "\t5 & 12433 & Nasjonal Innsjøundersøkelse 2019 & 71716 & 128-2-200 & Langevatnet & 2019-10-25 & 0 & 0 & Co        & NA &   0.760 & µg/L\\\\\n",
-       "\t6 & 12433 & Nasjonal Innsjøundersøkelse 2019 & 71716 & 128-2-200 & Langevatnet & 2019-10-25 & 0 & 0 & NO3+NO2-N & NA &  46.000 & µg/l\\\\\n",
+       "\t1 & 12433 & Nasjonal Innsjøundersøkelse 2019 & 71716 & 128-2-200 & Langevatnet & 2019-10-24 & 00:00:00 & 0 & 0 & Ca    & NA &   2.46 & mg/L\\\\\n",
+       "\t2 & 12433 & Nasjonal Innsjøundersøkelse 2019 & 71716 & 128-2-200 & Langevatnet & 2019-10-24 & 00:00:00 & 0 & 0 & K     & NA &   0.27 & mg/L\\\\\n",
+       "\t3 & 12433 & Nasjonal Innsjøundersøkelse 2019 & 71716 & 128-2-200 & Langevatnet & 2019-10-24 & 00:00:00 & 0 & 0 & Cl    & NA &   4.14 & mg/L\\\\\n",
+       "\t4 & 12433 & Nasjonal Innsjøundersøkelse 2019 & 71716 & 128-2-200 & Langevatnet & 2019-10-24 & 00:00:00 & 0 & 0 & NH4-N & NA &  13.00 & µg/l\\\\\n",
+       "\t5 & 12433 & Nasjonal Innsjøundersøkelse 2019 & 71716 & 128-2-200 & Langevatnet & 2019-10-24 & 00:00:00 & 0 & 0 & TOC   & NA &  19.70 & mg/l\\\\\n",
+       "\t6 & 12433 & Nasjonal Innsjøundersøkelse 2019 & 71716 & 128-2-200 & Langevatnet & 2019-10-24 & 00:00:00 & 0 & 0 & Al    & NA & 390.00 & µg/l\\\\\n",
        "\\end{tabular}\n"
       ],
       "text/markdown": [
        "\n",
-       "A data.frame: 6 × 12\n",
+       "A data.frame: 6 × 13\n",
        "\n",
-       "| <!--/--> | project_id &lt;int&gt; | project_name &lt;chr&gt; | station_id &lt;int&gt; | station_code &lt;chr&gt; | station_name &lt;chr&gt; | sample_date &lt;dttm&gt; | depth1 &lt;dbl&gt; | depth2 &lt;dbl&gt; | parameter_name &lt;chr&gt; | flag &lt;chr&gt; | value &lt;dbl&gt; | unit &lt;chr&gt; |\n",
-       "|---|---|---|---|---|---|---|---|---|---|---|---|---|\n",
-       "| 1 | 12433 | Nasjonal Innsjøundersøkelse 2019 | 71716 | 128-2-200 | Langevatnet | 2019-10-25 | 0 | 0 | Cl        | NA |   4.140 | mg/L |\n",
-       "| 2 | 12433 | Nasjonal Innsjøundersøkelse 2019 | 71716 | 128-2-200 | Langevatnet | 2019-10-25 | 0 | 0 | Cd        | NA |   0.039 | µg/l |\n",
-       "| 3 | 12433 | Nasjonal Innsjøundersøkelse 2019 | 71716 | 128-2-200 | Langevatnet | 2019-10-25 | 0 | 0 | Fe        | NA | 830.000 | µg/l |\n",
-       "| 4 | 12433 | Nasjonal Innsjøundersøkelse 2019 | 71716 | 128-2-200 | Langevatnet | 2019-10-25 | 0 | 0 | Mn        | NA |  19.000 | µg/l |\n",
-       "| 5 | 12433 | Nasjonal Innsjøundersøkelse 2019 | 71716 | 128-2-200 | Langevatnet | 2019-10-25 | 0 | 0 | Co        | NA |   0.760 | µg/L |\n",
-       "| 6 | 12433 | Nasjonal Innsjøundersøkelse 2019 | 71716 | 128-2-200 | Langevatnet | 2019-10-25 | 0 | 0 | NO3+NO2-N | NA |  46.000 | µg/l |\n",
+       "| <!--/--> | project_id &lt;int&gt; | project_name &lt;chr&gt; | station_id &lt;int&gt; | station_code &lt;chr&gt; | station_name &lt;chr&gt; | sample_date &lt;date&gt; | sample_time &lt;chr&gt; | depth1 &lt;dbl&gt; | depth2 &lt;dbl&gt; | parameter_name &lt;chr&gt; | flag &lt;chr&gt; | value &lt;dbl&gt; | unit &lt;chr&gt; |\n",
+       "|---|---|---|---|---|---|---|---|---|---|---|---|---|---|\n",
+       "| 1 | 12433 | Nasjonal Innsjøundersøkelse 2019 | 71716 | 128-2-200 | Langevatnet | 2019-10-24 | 00:00:00 | 0 | 0 | Ca    | NA |   2.46 | mg/L |\n",
+       "| 2 | 12433 | Nasjonal Innsjøundersøkelse 2019 | 71716 | 128-2-200 | Langevatnet | 2019-10-24 | 00:00:00 | 0 | 0 | K     | NA |   0.27 | mg/L |\n",
+       "| 3 | 12433 | Nasjonal Innsjøundersøkelse 2019 | 71716 | 128-2-200 | Langevatnet | 2019-10-24 | 00:00:00 | 0 | 0 | Cl    | NA |   4.14 | mg/L |\n",
+       "| 4 | 12433 | Nasjonal Innsjøundersøkelse 2019 | 71716 | 128-2-200 | Langevatnet | 2019-10-24 | 00:00:00 | 0 | 0 | NH4-N | NA |  13.00 | µg/l |\n",
+       "| 5 | 12433 | Nasjonal Innsjøundersøkelse 2019 | 71716 | 128-2-200 | Langevatnet | 2019-10-24 | 00:00:00 | 0 | 0 | TOC   | NA |  19.70 | mg/l |\n",
+       "| 6 | 12433 | Nasjonal Innsjøundersøkelse 2019 | 71716 | 128-2-200 | Langevatnet | 2019-10-24 | 00:00:00 | 0 | 0 | Al    | NA | 390.00 | µg/l |\n",
        "\n"
       ],
       "text/plain": [
@@ -369,13 +384,20 @@
        "4 12433      Nasjonal Innsjøundersøkelse 2019 71716      128-2-200   \n",
        "5 12433      Nasjonal Innsjøundersøkelse 2019 71716      128-2-200   \n",
        "6 12433      Nasjonal Innsjøundersøkelse 2019 71716      128-2-200   \n",
-       "  station_name sample_date depth1 depth2 parameter_name flag value   unit\n",
-       "1 Langevatnet  2019-10-25  0      0      Cl             NA     4.140 mg/L\n",
-       "2 Langevatnet  2019-10-25  0      0      Cd             NA     0.039 µg/l\n",
-       "3 Langevatnet  2019-10-25  0      0      Fe             NA   830.000 µg/l\n",
-       "4 Langevatnet  2019-10-25  0      0      Mn             NA    19.000 µg/l\n",
-       "5 Langevatnet  2019-10-25  0      0      Co             NA     0.760 µg/L\n",
-       "6 Langevatnet  2019-10-25  0      0      NO3+NO2-N      NA    46.000 µg/l"
+       "  station_name sample_date sample_time depth1 depth2 parameter_name flag value \n",
+       "1 Langevatnet  2019-10-24  00:00:00    0      0      Ca             NA     2.46\n",
+       "2 Langevatnet  2019-10-24  00:00:00    0      0      K              NA     0.27\n",
+       "3 Langevatnet  2019-10-24  00:00:00    0      0      Cl             NA     4.14\n",
+       "4 Langevatnet  2019-10-24  00:00:00    0      0      NH4-N          NA    13.00\n",
+       "5 Langevatnet  2019-10-24  00:00:00    0      0      TOC            NA    19.70\n",
+       "6 Langevatnet  2019-10-24  00:00:00    0      0      Al             NA   390.00\n",
+       "  unit\n",
+       "1 mg/L\n",
+       "2 mg/L\n",
+       "3 mg/L\n",
+       "4 µg/l\n",
+       "5 mg/l\n",
+       "6 µg/l"
       ]
      },
      "metadata": {},
@@ -390,6 +412,17 @@
     "df <- get_project_chemistry(proj_id, st_dt, end_dt, token = token)\n",
     "head(df)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -404,7 +437,7 @@
    "mimetype": "text/x-r-source",
    "name": "R",
    "pygments_lexer": "r",
-   "version": "4.0.4"
+   "version": "4.1.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
- Updates the project numbers column name in `get_projects` to account for new JSON format (following the [Aquamonitor-Python update](https://github.com/NIVANorge/Aquamonitor-Python/commit/3417d7046f3c6e1fcb738defc1fa301bc117e247))
- Uses `bind_rows` from `dplyr` package instead of `rbind` (data.frames not having the same number of columns resulting in error)
- Splits date & time in returned data.frame in `get_project_chemistry` function
- Updates the example notebook